### PR TITLE
Adding treasure and speed minimums

### DIFF
--- a/FishingMinigames/FishingMinigames.csproj
+++ b/FishingMinigames/FishingMinigames.csproj
@@ -4,9 +4,8 @@
     <RootNamespace>FishingMinigames</RootNamespace>
     <AssemblyName>FishingMinigames</AssemblyName>
     <Version>1.0.0</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <EnableHarmony>true</EnableHarmony>
-    <GameModsPath>D:\Programs\Steam\steamapps\common\Stardew Valley 155\ModsTesting</GameModsPath>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="assets\audio\source\**" />
@@ -33,7 +32,7 @@
     <Content Include="assets\tackle_spinners.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.3.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.0.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="config info readme.txt">

--- a/FishingMinigames/MinigamesStart.cs
+++ b/FishingMinigames/MinigamesStart.cs
@@ -119,7 +119,16 @@ namespace FishingMinigames
                 else offset += (int)(140 * startMinigameScale);
             }
             //vanilla treasure chance calculation
-            if (fishingFestivalMinigame == 0 && who.fishCaught != null && who.fishCaught.Count() > 1 && Game1.random.NextDouble() < who.LuckLevel * 0.005 + data.effects["TREASURE"] + who.DailyLuck / 2.0 + ((who.professions.Contains(9) ? FishingRod.baseChanceForTreasure : 0)))
+            if (fishingFestivalMinigame == 0                                                    // Not in a festival
+                && who.fishCaught != null && who.fishCaught.Count() > 1                         // Caught a fish
+                && Game1.random.NextDouble()                                                    // RNG
+                < (   who.LuckLevel * 0.005                                                     // Consumables + Rings
+                    + data.effects["TREASURE"]                                                  // The modifier on rods
+                    + who.DailyLuck / 2.0                                                       // Daily Luck
+                    + 0.07                                                                      // Flat amount - in vanilla this is 15%, but we can fish 2-3x as fast so make it 7%
+                    + ((who.professions.Contains(9) ? FishingRod.baseChanceForTreasure : 0))    // The Pirate profession
+                  )
+               )
             {
                 minigameData[4] = Game1.random.Next(minigameArrowData.Length / 2, minigameArrowData.Length - 1);
             }
@@ -257,6 +266,7 @@ namespace FishingMinigames
                     else if (fishingFestivalMinigame == 1) speed += (festivalDifficulty / 2f - (fishingLevel / 10f)) * minigameDifficulty[screen];
                     else if (fishingFestivalMinigame == 2) speed += (festivalDifficulty / 1.6f - (fishingLevel / 10f)) * minigameDifficulty[screen];
 
+                    if (speed <= 1f) speed = 1f;
                     minigameTimer -= (int)(startMinigameScale * speed);
                 }
 

--- a/FishingMinigames/MinigamesStart.cs
+++ b/FishingMinigames/MinigamesStart.cs
@@ -266,7 +266,7 @@ namespace FishingMinigames
                     else if (fishingFestivalMinigame == 1) speed += (festivalDifficulty / 2f - (fishingLevel / 10f)) * minigameDifficulty[screen];
                     else if (fishingFestivalMinigame == 2) speed += (festivalDifficulty / 1.6f - (fishingLevel / 10f)) * minigameDifficulty[screen];
 
-                    if (speed <= 1f) speed = 1f;
+                    if (speed <= 1) speed = 1f;
                     minigameTimer -= (int)(startMinigameScale * speed);
                 }
 
@@ -625,6 +625,7 @@ namespace FishingMinigames
                     else if (fishingFestivalMinigame == 1) speed += (festivalDifficulty / 2f - (fishingLevel / 10f)) * minigameDifficulty[screen];
                     else if (fishingFestivalMinigame == 2) speed += (festivalDifficulty / 1.6f - (fishingLevel / 10f)) * minigameDifficulty[screen];
 
+                    if (speed <= 1) speed = 1f;
                     minigameTimer -= (int)(startMinigameScale * speed);
                 }
 


### PR DESCRIPTION
Added a minimum treasure chance of 7% (up from 0%).
Added a check to prevent a minigame speed of 0, causing a soft lock.